### PR TITLE
Fix/add name to trace request

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -8,7 +8,24 @@ This document contains change notes for bugfix releases in the 3.1.x series
 (Cipater), please see :ref:`whatsnew-3.1` for an overview of what's
 new in Celery 3.1.
 
-.. _version-3.1.26:
+.. _version-3.1.26.ud4:
+
+3.1.26-ud4
+======
+- Fixed trace.py to capture task_name in its request object
+
+3.1.26-ud3
+======
+- Bug fixes to ud2
+
+3.1.26-ud2
+======
+- Bug fixes to ud1
+
+3.1.26-ud1
+======
+- Introduce extended results from 4.x into 3.x to help store args/kwargs as
+  well as other values
 
 3.1.26
 ======

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 .. image:: http://cloud.github.com/downloads/celery/celery/celery_128.png
 
-:Version: 3.1.26.ud3 (Cipater)
+:Version: 3.1.26.ud4 (Cipater)
 :Web: http://celeryproject.org/
 :Download: http://pypi.python.org/pypi/celery/
 :Source: http://github.com/celery/celery/

--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -19,7 +19,7 @@ version_info_t = namedtuple(
 )
 
 SERIES = 'Cipater'
-VERSION = version_info_t(3, 1, 26, '_ud3', '')
+VERSION = version_info_t(3, 1, 26, '_ud4', '')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -93,6 +93,7 @@ class TraceInfo(object):
         try:
             reason = self.retval
             einfo = ExceptionInfo((type_, reason, tb))
+            req.update(task_name=task.name)
             if store_errors:
                 task.backend.mark_as_retry(
                     req.id, reason.exc, einfo.traceback, request=req,
@@ -113,6 +114,7 @@ class TraceInfo(object):
             einfo = ExceptionInfo()
             einfo.exception = get_pickleable_exception(einfo.exception)
             einfo.type = get_pickleable_etype(einfo.type)
+            req.update(task_name=task.name)
             if store_errors:
                 task.backend.mark_as_failure(
                     req.id, exc, einfo.traceback, request=req,

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -93,7 +93,6 @@ class TraceInfo(object):
         try:
             reason = self.retval
             einfo = ExceptionInfo((type_, reason, tb))
-            req.update(task_name=task.name)
             if store_errors:
                 task.backend.mark_as_retry(
                     req.id, reason.exc, einfo.traceback, request=req,
@@ -114,7 +113,6 @@ class TraceInfo(object):
             einfo = ExceptionInfo()
             einfo.exception = get_pickleable_exception(einfo.exception)
             einfo.type = get_pickleable_etype(einfo.type)
-            req.update(task_name=task.name)
             if store_errors:
                 task.backend.mark_as_failure(
                     req.id, exc, einfo.traceback, request=req,
@@ -223,7 +221,8 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
         try:
             push_task(task)
             task_request = Context(request or {}, args=args,
-                                   called_directly=False, kwargs=kwargs)
+                                   called_directly=False, kwargs=kwargs,
+                                   task_name=task.name)
             push_request(task_request)
             try:
                 # -*- PRE -*-

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,4 +1,4 @@
-:Version: 3.1.26.ud3 (Cipater)
+:Version: 3.1.26.ud4 (Cipater)
 :Web: http://celeryproject.org/
 :Download: http://pypi.python.org/pypi/celery/
 :Source: http://github.com/celery/celery/


### PR DESCRIPTION
@rickhutcheson @udemy/platform 

Update the request object in celery.app.trace before it submits the request into the result store. Currently, the request['task_name'] is None and will wipe out the name attribute existing in the result store.
