### PR TITLE
Enable eta to be stored/retrieved as a result.

### DIFF
--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -525,6 +525,7 @@ class KeyValueStoreBackend(BaseBackend):
                     'name': getattr(request, 'task_name', None),
                     'args': getattr(request, 'args', None),
                     'kwargs': getattr(request, 'kwargs', None),
+                    'eta': getattr(request, 'eta', None),
                     'worker': getattr(request, 'hostname', None),
                     'retries': getattr(request, 'retries', None),
                     'queue': request.delivery_info.get('routing_key')

--- a/celery/result.py
+++ b/celery/result.py
@@ -431,6 +431,10 @@ class AsyncResult(ResultBase):
     def queue(self):
         return self._get_task_meta().get('queue')
 
+    @property
+    def eta(self):
+        return self._get_task_meta().get('eta')
+
 
 class ResultSet(ResultBase):
     """Working with more than one result.


### PR DESCRIPTION
@rickhutcheson @udemy/platform 

This enables the eta to be stored and retrieved from the result backend if it's set in the Context wrapper.