### PR TITLE
Revert "Add app_name as a signal item on prerun and postrun."

### DIFF
--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -80,8 +80,6 @@ def _reprtask(task, fmt=None, flags=None):
 
 class Context(object):
     # Default context
-    garden_name = None
-    app_name = None
     logfile = None
     loglevel = None
     hostname = None

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -228,8 +228,6 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                 # -*- PRE -*-
                 if prerun_receivers:
                     send_prerun(sender=task, task_id=uuid, task=task,
-                                garden_name=task_request.garden_name,
-                                app_name=task_request.app_name,
                                 args=args, kwargs=kwargs)
                 loader_task_init(uuid, task)
                 if track_started:
@@ -306,9 +304,7 @@ def build_tracer(name, task, loader=None, hostname=None, store_errors=True,
                     if postrun_receivers:
                         send_postrun(sender=task, task_id=uuid, task=task,
                                      args=args, kwargs=kwargs,
-                                     retval=retval, state=state,
-                                     app_name=task_request.app_name,
-                                     garden_name=task_request.garden_name)
+                                     retval=retval, state=state)
                 finally:
                     pop_task()
                     pop_request()

--- a/celery/signals.py
+++ b/celery/signals.py
@@ -36,11 +36,9 @@ after_task_publish = Signal(providing_args=[
 task_sent = Signal(providing_args=[
     'task_id', 'task', 'args', 'kwargs', 'eta', 'taskset',
 ])
-task_prerun = Signal(providing_args=[
-    'task_id', 'task', 'args', 'kwargs', 'app_name', 'garden_name',
-])
+task_prerun = Signal(providing_args=['task_id', 'task', 'args', 'kwargs'])
 task_postrun = Signal(providing_args=[
-    'task_id', 'task', 'args', 'kwargs', 'retval', 'app_name', 'garden_name',
+    'task_id', 'task', 'args', 'kwargs', 'retval',
 ])
 task_success = Signal(providing_args=['result'])
 task_retry = Signal(providing_args=[


### PR DESCRIPTION
Reverts udemy/celery#7

We don't need this anymore.

@rickhutcheson @udemy/platform 