### PR TITLE
Backport SSL support for RedisBackend from Celery 4

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -10,6 +10,10 @@ new in Celery 3.1.
 
 .. _version-3.1.26.ud8:
 
+3.1.26-ud9
+======
+- Backport SSL support from Celery 4 to RedisBackend
+
 3.1.26-ud8
 ======
 - Revert 3.1.26-ud7 changes due to spike in CPU usage.

--- a/Changelog
+++ b/Changelog
@@ -8,7 +8,7 @@ This document contains change notes for bugfix releases in the 3.1.x series
 (Cipater), please see :ref:`whatsnew-3.1` for an overview of what's
 new in Celery 3.1.
 
-.. _version-3.1.26.ud8:
+.. _version-3.1.26.ud9:
 
 3.1.26-ud9
 ======

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 .. image:: http://cloud.github.com/downloads/celery/celery/celery_128.png
 
-:Version: 3.1.26.ud8 (Cipater)
+:Version: 3.1.26.ud9 (Cipater)
 :Web: http://celeryproject.org/
 :Download: http://pypi.python.org/pypi/celery/
 :Source: http://github.com/celery/celery/

--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -19,7 +19,7 @@ version_info_t = namedtuple(
 )
 
 SERIES = 'Cipater'
-VERSION = version_info_t(3, 1, 26, '_ud8', '')
+VERSION = version_info_t(3, 1, 26, '_ud9', '')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/celery/backends/__init__.py
+++ b/celery/backends/__init__.py
@@ -28,6 +28,7 @@ BACKEND_ALIASES = {
     'rpc': 'celery.backends.rpc.RPCBackend',
     'cache': 'celery.backends.cache:CacheBackend',
     'redis': 'celery.backends.redis:RedisBackend',
+    'rediss': 'celery.backends.redis:RedisBackend',
     'mongodb': 'celery.backends.mongodb:MongoBackend',
     'db': 'celery.backends.database:DatabaseBackend',
     'database': 'celery.backends.database:DatabaseBackend',

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -102,7 +102,7 @@ class RedisBackend(KeyValueStoreBackend):
             host = None
 
         self.max_connections = (
-                max_connections or _get('MAX_CONNECTIONS') or self.max_connections
+            max_connections or _get('MAX_CONNECTIONS') or self.max_connections
         )
         self._ConnectionPool = connection_pool
 


### PR DESCRIPTION
## Description

Backport SSL support for `RedisBackend`

Here's the backport: https://github.com/celery/celery/blob/master/celery/backends/redis.py
