### PR TITLE
Adding patch for hanging workers

### DIFF
--- a/celery/concurrency/asynpool.py
+++ b/celery/concurrency/asynpool.py
@@ -709,10 +709,10 @@ class AsynPool(_pool.Pool):
                     fileno_to_inq.pop(fd, None)
                     active_writes.discard(fd)
                     all_inqueues.discard(fd)
-                    hub_remove(fd)
             except KeyError:
                 pass
         self.on_inqueue_close = on_inqueue_close
+        self.hub_remove = hub_remove
 
         def schedule_writes(ready_fds, curindex=[0]):
             # Schedule write operation to ready file descriptor.
@@ -1217,6 +1217,7 @@ class AsynPool(_pool.Pool):
             if queue:
                 for sock in (queue._reader, queue._writer):
                     if not sock.closed:
+                        self.hub_remove(sock)
                         try:
                             sock.close()
                         except (IOError, OSError):


### PR DESCRIPTION
Adding patch for celery#4185 (comment)


## Description

This is based on a Celery issue that closely describers what might be happening with our Celery workers. In the issue above people describe hanging descriptors blocking workers. I tired to go back in time in the celery repo to see when it was added and what has changed. The hope is that the descriptors are closed correctly unblocking workers. 