### PR TITLE
Bugfix: Prevent Redis cluster CROSSSLOT errors for Celery chord task results

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -20,7 +20,7 @@ from . import local  # noqa
 
 SERIES = 'cliffs'
 
-__version__ = '4.4.7+ud1'
+__version__ = '4.4.7+ud2'
 __author__ = 'Ask Solem'
 __contact__ = 'auvipy@gmail.com'
 __homepage__ = 'http://celeryproject.org'

--- a/celery/backends/base.py
+++ b/celery/backends/base.py
@@ -765,10 +765,11 @@ class BaseKeyValueStoreBackend(Backend):
         ])
 
     def get_key_for_group(self, group_id, key=''):
-        """Get the cache key for a group by id."""
+        """Get the cache key for a group by id.
+        Use the group_id as a hash tag to use same redis cluster node slot"""
         key_t = self.key_t
         return key_t('').join([
-            self.group_keyprefix, key_t(group_id), key_t(key),
+            self.group_keyprefix, key_t('{{{}}}'.format(group_id)), key_t(key),
         ])
 
     def get_key_for_chord(self, group_id, key=''):


### PR DESCRIPTION
This PR fixes an issue seen since the Celery 4 upgrade where Celery chord subtasks cause redis cluster CROSSSLOT [errors](https://app.datadoghq.com/apm/resource/redis/redis.command/c2e02d5c48ff37c1?query=env%3Aproduction%20service%3Aredis%20operation_name%3Aredis.command%20resource_name%3A%22RPUSH%20LLEN%20GET%20...%22&env=production&fullscreen_end_ts=1634305964000&fullscreen_paused=false&fullscreen_start_ts=1629035564000&hostGroup=%2A&index=apm-search&topGraphs=latency%3Alatency%2Cerrors%3Acount%2Chits%3Arate&start=1631713931285&end=1634305931285&paused=false) when updating their status.
Using a hash tag within the redis key enforces the use of a consistent hash slot for redis clusters (see https://aws.amazon.com/premiumsupport/knowledge-center/elasticache-crossslot-keys-error-redis/)